### PR TITLE
feat: add 40+ rules

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -24,24 +24,46 @@
     "no-lone-blocks": "error",
     "no-labels": "error",
     "no-extra-label": "error",
+    "no-else-return": "warn",
+    "no-constructor-return": "error",
+    "no-self-compare": "error",
     "sort-imports": "off",
 
     "unicorn/prefer-string-starts-ends-with": "error",
     "unicorn/prefer-string-trim-start-end": "error",
+    "unicorn/prefer-string-slice": "warn",
+    "unicorn/prefer-string-raw": "warn",
     "unicorn/prefer-spread": "error",
     "unicorn/prefer-logical-operator-over-ternary": "warn",
     "unicorn/prefer-includes": "error",
     "unicorn/prefer-array-index-of": "warn",
+    "unicorn/prefer-array-flat-map": "warn",
     "unicorn/prefer-object-from-entries": "warn",
     "unicorn/prefer-optional-catch-binding": "error",
     "unicorn/prefer-global-this": "warn",
+    "unicorn/prefer-negative-index": "warn",
+    "unicorn/prefer-set-size": "warn",
+    "unicorn/prefer-structured-clone": "warn",
+    "unicorn/prefer-blob-reading-methods": "warn",
+    "unicorn/prefer-dom-node-append": "warn",
+    "unicorn/prefer-dom-node-remove": "warn",
+    "unicorn/prefer-node-protocol": "warn",
     "unicorn/no-nested-ternary": "warn",
+    "unicorn/no-negated-condition": "warn",
+    "unicorn/no-typeof-undefined": "warn",
+    "unicorn/no-lonely-if": "warn",
+    "unicorn/no-useless-promise-resolve-reject": "error",
+    "unicorn/no-instanceof-array": "error",
+    "unicorn/no-thenable": "error",
+    "unicorn/no-negation-in-equality-check": "error",
     "unicorn/no-console-spaces": "error",
     "unicorn/empty-brace-spaces": "error",
     "unicorn/throw-new-error": "error",
     "unicorn/number-literal-case": "error",
     "unicorn/no-zero-fractions": "error",
     "unicorn/consistent-existence-index-check": "warn",
+    "unicorn/consistent-empty-array-spread": "warn",
+    "unicorn/require-array-join-separator": "warn",
 
     "no-var": "error",
     "no-debugger": "error",
@@ -55,15 +77,22 @@
     "typescript/no-unnecessary-type-arguments": "error",
     "typescript/no-unnecessary-type-assertion": "error",
     "typescript/no-unnecessary-type-constraint": "error",
+    "typescript/no-unnecessary-qualifier": "warn",
+    "typescript/no-useless-empty-export": "warn",
+    "typescript/no-duplicate-enum-values": "error",
+    "typescript/no-mixed-enums": "error",
+    "typescript/no-unsafe-declaration-merging": "error",
     "typescript/non-nullable-type-assertion-style": "error",
     "typescript/prefer-as-const": "error",
+    "typescript/prefer-optional-chain": "warn",
+    "typescript/prefer-nullish-coalescing": "warn",
+    "typescript/prefer-function-type": "error",
+    "typescript/prefer-for-of": "warn",
     "typescript/array-type": "error",
     "typescript/ban-ts-comment": "error",
     "typescript/consistent-indexed-object-style": "error",
     "typescript/no-namespace": "error",
-    "typescript/prefer-function-type": "error",
     "typescript/prefer-namespace-keyword": "error",
-    "typescript/prefer-for-of": "warn",
     "typescript/no-confusing-void-expression": "off",
     "typescript/no-floating-promises": "off",
     "typescript/no-var-requires": "off",
@@ -79,16 +108,67 @@
     "react/jsx-fragments": "error",
     "react/jsx-no-useless-fragment": "error",
     "react/jsx-boolean-value": "error",
+    "react/jsx-no-duplicate-props": "error",
     "react/rules-of-hooks": "error",
+    "react/void-dom-elements-no-children": "error",
+    "react/no-danger": "warn",
+    "react/jsx-no-constructed-context-values": "warn",
     "react/no-unknown-property": "off",
     "react/react-in-jsx-scope": "off",
     "react/jsx-key": "warn",
 
+    "react_perf/jsx-no-jsx-as-prop": "warn",
+
+    "oxc/no-accumulating-spread": "error",
+    "oxc/no-map-spread": "warn",
+
+    "import/no-cycle": "error",
     "import/no-duplicates": "error",
     "import/first": "error",
     "import/exports-last": "off",
     "import/no-anonymous-default-export": "warn"
   },
+  "settings": {
+    "jsx-a11y": {
+      "polymorphicPropName": null,
+      "components": {},
+      "attributes": {}
+    },
+    "next": {
+      "rootDir": []
+    },
+    "react": {
+      "formComponents": [],
+      "linkComponents": [],
+      "version": "18"
+    },
+    "jsdoc": {
+      "ignorePrivate": false,
+      "ignoreInternal": false,
+      "ignoreReplacesDocs": true,
+      "overrideReplacesDocs": true,
+      "augmentsExtendsReplacesDocs": false,
+      "implementsReplacesDocs": false,
+      "exemptDestructuredRootsFromChecks": false,
+      "tagNamePreference": {}
+    }
+  },
+  "env": {
+    "builtin": true,
+    "browser": true,
+    "es2021": true,
+    "node": true,
+    "worker": true,
+    "mocha": true,
+    "jest": true
+  },
+  "globals": {
+    "Atomics": "readonly",
+    "SharedArrayBuffer": "readonly"
+  },
+  "ignorePatterns": ["node_modules/**", "dist/**", "build/**", "coverage/**", ".next/**", "out/**"]
+}
+
   "settings": {
     "jsx-a11y": {
       "polymorphicPropName": null,

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ deno task lint
 
 ## 🔧 Complete Rule Reference
 
-70+ carefully selected rules across:
+110+ carefully selected rules across:
 
 ### JavaScript Standard Style
 
@@ -171,6 +171,9 @@ deno task lint
 - `no-var` - Use `const`/`let`
 - `space-infix-ops` - Proper spacing
 - `yoda` - Readable comparisons
+- `no-constructor-return` - No return values from constructors
+- `no-self-compare` - Flags `x === x` tautologies
+- `no-else-return` - Removes redundant else after return
 
 ### Modern JavaScript
 
@@ -184,18 +187,49 @@ deno task lint
 - `rules-of-hooks` - Proper hooks usage
 - `jsx-curly-brace-presence` - Clean JSX
 - `self-closing-comp` - Concise components
+- `jsx-no-duplicate-props` - Catches duplicate prop bugs
+- `void-dom-elements-no-children` - No children on `<img>`, `<br>` etc.
+- `no-danger` *(warn)* - Flags `dangerouslySetInnerHTML`
+- `jsx-no-constructed-context-values` *(warn)* - Prevents needless re-renders
+- `react_perf/jsx-no-jsx-as-prop` *(warn)* - JSX in props causes re-renders
 
 ### TypeScript Integration
 
 - `consistent-type-imports` - Clean imports
 - `array-type` - Consistent syntax
 - `prefer-as-const` - Type assertions
+- `prefer-optional-chain` - `a?.b` over `a && a.b`
+- `prefer-nullish-coalescing` - `??` over `||` for null checks
+- `no-unnecessary-qualifier` - Removes redundant namespace qualifiers
+- `no-useless-empty-export` - Removes redundant `export {}`
+- `no-duplicate-enum-values` / `no-mixed-enums` - Enum correctness guards
+- `no-unsafe-declaration-merging` - Class+interface merge safety
 
 ### Enhanced Patterns (Unicorn)
 
 - `prefer-includes` - Better array methods
 - `prefer-string-starts-ends-with` - Modern strings
 - `throw-new-error` - Proper errors
+- `prefer-string-slice` - `.slice()` over `.substring()`
+- `prefer-node-protocol` - `'node:fs'` over `'fs'`
+- `prefer-negative-index` - `arr.at(-1)` over `arr[arr.length - 1]`
+- `prefer-structured-clone` - `structuredClone()` over JSON round-trip
+- `no-negated-condition` - Flips negated if/ternary for readability
+- `no-typeof-undefined` - `x === undefined` over `typeof x`
+- `no-lonely-if` - Hoists lone `if` out of `else`
+- `no-useless-promise-resolve-reject` - Removes redundant wrappers
+- `no-instanceof-array` - `Array.isArray()` over `instanceof Array`
+- `no-negation-in-equality-check` - `!!x === y` instead of `!x === y`
+- `require-array-join-separator` - Explicit separator in `.join()`
+
+### Performance (Oxc)
+
+- `no-accumulating-spread` - Prevents O(n²) spread in loops
+- `no-map-spread` *(warn)* - Spread in map callbacks
+
+### Import Safety
+
+- `import/no-cycle` - Detects circular imports
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ deno task lint
 
 ## 🔧 Complete Rule Reference
 
-110+ carefully selected rules across:
+100+ carefully selected rules across:
 
 ### JavaScript Standard Style
 


### PR DESCRIPTION
## New rules

### Unicorn (19 new)
- `prefer-string-slice` — prefers `.slice()` over `.substring()`
- `prefer-string-raw` — use `String.raw` for regex-like strings
- `prefer-node-protocol` — `'node:fs'` over `'fs'`
- `prefer-array-flat-map` — `.flatMap()` over `.map().flat()`
- `prefer-negative-index` — `arr.at(-1)` over `arr[arr.length - 1]`
- `prefer-set-size` — `.size` idiom guard
- `prefer-structured-clone` — `structuredClone()` over JSON round-trip
- `prefer-blob-reading-methods` — `.text()` over FileReader
- `prefer-dom-node-append` / `prefer-dom-node-remove` — modern DOM API
- `no-negated-condition` — flips negated if/ternary for readability
- `no-typeof-undefined` — `x === undefined` over `typeof x === 'undefined'`
- `no-lonely-if` — hoists lone `if` out of `else` block
- `no-useless-promise-resolve-reject` — removes redundant wrapper
- `no-instanceof-array` — `Array.isArray()` over `instanceof Array`
- `no-thenable` — prevents accidental thenable objects
- `no-negation-in-equality-check` —
- `consistent-empty-array-spread` — consistent spread syntax
- `require-array-join-separator` — explicit separator in `.join()`

### TypeScript (7 new)
- `prefer-optional-chain` / `prefer-nullish-coalescing`
- `no-unnecessary-qualifier` — redundant namespace qualifiers
- `no-useless-empty-export` — redundant `export {}`
- `no-duplicate-enum-values` / `no-mixed-enums` — enum correctness
- `no-unsafe-declaration-merging` — class+interface merge safety

### React (5 new)
- `jsx-no-duplicate-props` — catches duplicate prop bug
- `void-dom-elements-no-children` — no children on `<img>`, `<br>` etc.
- `no-danger` (warn) — flags dangerouslySetInnerHTML
- `jsx-no-constructed-context-values` (warn) — prevent needless re-renders
- `react_perf/jsx-no-jsx-as-prop` (warn) — JSX in props causes re-renders

### Oxc (2 new)
- `no-accumulating-spread` (error) — O(n²) spread in loops
- `no-map-spread` (warn) — spread in map callbacks

### Core (4 new)
- `no-else-return` — removes redundant else after return
- `no-constructor-return` — no return values from constructors
- `no-self-compare` — flags `x === x` tautologies
- `import/no-cycle` — detects circular imports