### PR TITLE
fix(.oxlintrc): repair malformed config blocking oxlint from loading

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -6,7 +6,6 @@
     "style": "off"
   },
   "rules": {
-    "space-infix-ops": "error",
     "eqeqeq": "error",
     "curly": "allow",
     "yoda": "error",
@@ -169,43 +168,3 @@
   "ignorePatterns": ["node_modules/**", "dist/**", "build/**", "coverage/**", ".next/**", "out/**"]
 }
 
-  "settings": {
-    "jsx-a11y": {
-      "polymorphicPropName": null,
-      "components": {},
-      "attributes": {}
-    },
-    "next": {
-      "rootDir": []
-    },
-    "react": {
-      "formComponents": [],
-      "linkComponents": [],
-      "version": "18"
-    },
-    "jsdoc": {
-      "ignorePrivate": false,
-      "ignoreInternal": false,
-      "ignoreReplacesDocs": true,
-      "overrideReplacesDocs": true,
-      "augmentsExtendsReplacesDocs": false,
-      "implementsReplacesDocs": false,
-      "exemptDestructuredRootsFromChecks": false,
-      "tagNamePreference": {}
-    }
-  },
-  "env": {
-    "builtin": true,
-    "browser": true,
-    "es2021": true,
-    "node": true,
-    "worker": true,
-    "mocha": true,
-    "jest": true
-  },
-  "globals": {
-    "Atomics": "readonly",
-    "SharedArrayBuffer": "readonly"
-  },
-  "ignorePatterns": ["node_modules/**", "dist/**", "build/**", "coverage/**", ".next/**", "out/**"]
-}


### PR DESCRIPTION
Two issues prevented oxlint from loading `.oxlintrc.json` (discovered while consuming ox-standard from a fresh Expo project):

### 1. Trailing duplicate block (lines 172–211)
After the top-level closing `}` on line 170 the file contained an exact copy of the bottom half (settings/env/globals/ignorePatterns). oxlint refused to parse with:

```
x invalid config file .../.oxlintrc.json: Failed to parse oxlint config.
| trailing characters at line 172 column 3
```

### 2. Unsupported rule `space-infix-ops`
oxlint doesn't ship this rule:

```
x Rule 'space-infix-ops' not found in plugin 'eslint'
```

Infix-operator spacing is handled by **oxfmt**, so removing the rule from oxlint is the correct fix.

### Verification
```
npx vitest run lint-test/all-lint-rules.test.ts
✓ 3 tests passed
```

After applying these fixes, downstream projects (e.g. consumers running `npx JohnDeved/ox-standard` then `oxlint .`) work out of the box.